### PR TITLE
fix: add missing folder to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ It was made to be fast and easy to use.
 
 To starting using immTagCo, install it with your favorite plugin manager.
 
-To install the plugin manually, follow these two steps.
+To install the plugin manually, follow these three steps.
 - Step 1: create a folder for the plugin inside the Vim package
-folder, e.g. ".vim/pack/plugins/start/immTagCo".
-- Step 2: copy the main plugin file into the created folder.
+folder, e.g. ".vim/pack/plugins/start/immTagCo/".
+- Step 2: inside the folder created in the previous step, create a folder 
+named "plugin".
+- Step 3: copy the main plugin file into the "plugin" folder created in the 
+previous step. The path to the main plugin file should look like 
+".vim/pack/plugins/start/immTagCo/plugin/immTagCo.vim".
 


### PR DESCRIPTION
Add missing instruction to put the main plugin file inside the "plugin" folder.