### PR TITLE
fix: check if the first element written is void

### DIFF
--- a/plugin/immTagCo.vim
+++ b/plugin/immTagCo.vim
@@ -139,15 +139,18 @@
      \   g:immTagCoValidTagCharacterPattern
      \ )
 
+   " Stores in a variable if the file being edited is in HTML format:
+:  if !exists("b:isUsingHtmlSyntax")
+:    let b:isUsingHtmlSyntax = (
+       \ &filetype =~? '\%(html\|xml\|svelte\|vue\|jsx\|tsx\|php\)')
+:  endif
+
    " Checks if the tag needs a closing tag:
-:  if (exists("b:isUsingHtmlSyntax") && b:isUsingHtmlSyntax)
+:  if b:isUsingHtmlSyntax
 :    let isVoidElement = index(g:immTagCoVoidElements, tagText, 0, 1) >= 0
 :    if isVoidElement
 :      return
 :    endif
-:  else
-:    let b:isUsingHtmlSyntax = (
-       \ &filetype =~? '\%(html\|xml\|svelte\|vue\|jsx\|tsx\|php\)')
 :  endif
 
    " Searches for the position of the closing angle bracket of the closest


### PR DESCRIPTION
Perform a check to know if the element needs a closing tag on the first element written.
Previously the check was not being done on the first element, only on the next ones.