### PR TITLE
refactor: add variable with supported filetypes

### DIFF
--- a/plugin/immTagCo.vim
+++ b/plugin/immTagCo.vim
@@ -97,6 +97,8 @@
 :  let g:immTagCoMaxNumberOfLinesToSearch = 10
 :  let g:immTagCoMaxTagTextLength = 20
 :  let g:turnOffImmTagCo = 0
+:  let g:immTagCoSupportedFiletypes = ["html", "xml", "js", "svelte", "vue",
+     \ "jsx", "tsx", "php"]
 :endfunction
 
 :function immTagCo#saveUseOfHtmlInBuffer()


### PR DESCRIPTION
Save the filetypes supported by the plugin as a list in a global variable.