### PR TITLE
feat: support files that change filetype dynamically

### DIFF
--- a/plugin/immTagCo.vim
+++ b/plugin/immTagCo.vim
@@ -114,6 +114,26 @@
 :  call immTagCo#saveUseOfHtmlInBuffer()
 :endfunction
 
+" Moves the cursor to the column between the opening and closing tags.
+:function immTagCo#RestoreCursor()
+:  if !s:hasToMoveCursorAfterOpeningTag
+:    return
+:  endif
+
+:  execute('normal ' . repeat('h', s:lastTagLength))
+
+:  let s:hasToMoveCursorAfterOpeningTag = 0
+:  let s:lastTagLength = 0
+:endfunction
+
+:function s:addAutocmdToRestoreCursor()
+:  augroup immTagCoGroup
+:    autocmd TextChangedI,TextChangedP
+     \ *.html,*.xml,*.js,*.svelte,*.vue,*.jsx,*.tsx,*.php once call
+     \ immTagCo#RestoreCursor()
+:  augroup END
+:endfunction
+
 " Main function, does the tag completion.
 :function immTagCo#CompleteImmediateTag()
    " Stops if the plugin is turned off:
@@ -196,20 +216,10 @@
 :  let s:hasToMoveCursorAfterOpeningTag = 1
 :  let s:lastTagLength = len(tagText) + 3
 
+:  call s:addAutocmdToRestoreCursor()
+
    " Restores the setting to its value at the start:
 :  let &cpo = savedCpo
-:endfunction
-
-" Moves the cursor to the column between the opening and closing tags.
-:function immTagCo#RestoreCursor()
-:  if !s:hasToMoveCursorAfterOpeningTag
-:    return
-:  endif
-
-:  execute('normal ' . repeat('h', s:lastTagLength))
-
-:  let s:hasToMoveCursorAfterOpeningTag = 0
-:  let s:lastTagLength = 0
 :endfunction
 
 " Initializes the plugin:
@@ -223,9 +233,6 @@
 :    autocmd!
 :    autocmd InsertCharPre *.html,*.xml,*.js,*.svelte,*.vue,*.jsx,*.tsx,*.php
        \ call immTagCo#CompleteImmediateTag()
-:    autocmd TextChangedI,TextChangedP 
-       \ *.html,*.xml,*.js,*.svelte,*.vue,*.jsx,*.tsx,*.php call
-       \ immTagCo#RestoreCursor()
      autocmd FileType * call immTagCo#loadPluginInBuffer()
 :  augroup END
 

--- a/plugin/immTagCo.vim
+++ b/plugin/immTagCo.vim
@@ -231,8 +231,7 @@
 "  Registers the appropriate functions to the events of inserting a character
 :  augroup immTagCoGroup
 :    autocmd!
-:    autocmd InsertCharPre *.html,*.xml,*.js,*.svelte,*.vue,*.jsx,*.tsx,*.php
-       \ call immTagCo#CompleteImmediateTag()
+:    autocmd InsertCharPre * call immTagCo#CompleteImmediateTag()
      autocmd FileType * call immTagCo#loadPluginInBuffer()
 :  augroup END
 

--- a/plugin/immTagCo.vim
+++ b/plugin/immTagCo.vim
@@ -121,6 +121,18 @@
 :    return
 :  endif
 
+:  let fileExtension = expand("%:e")
+:  let isExtensionSupported =
+     / index(g:immTagCoSupportedFiletypes, fileExtension, 0, 1) >= 0
+:  let isFiletypeSupported = index(g:immTagCoSupportedFiletypes, &filetype, 0, 1) >= 0
+:  let isCurrentFileSupported = isExtensionSupported || isFiletypeSupported
+
+   " Stops if both the extension and the filetype of the current file are not
+   " supported by the plugin:
+:  if !isCurrentFileSupported
+:    return
+:  endif
+
    " Stops if the last inserted character is not a closing character:
 :  let isClosingCharacter = v:char ==? ">"
 :  if !isClosingCharacter


### PR DESCRIPTION
Update the autocmd that inserts the closing tag to run for all file extensions.
A check is made on extension and filetype to only proceed to tag completion on supported files.
Only tries to restore cursor position after a closing tag is inserted.