### PR TITLE
fix: autocmd's once keyword must have plus signs

### DIFF
--- a/plugin/immTagCo.vim
+++ b/plugin/immTagCo.vim
@@ -129,7 +129,7 @@
 :function s:addAutocmdToRestoreCursor()
 :  augroup immTagCoGroup
 :    autocmd TextChangedI,TextChangedP
-     \ *.html,*.xml,*.js,*.svelte,*.vue,*.jsx,*.tsx,*.php once call
+     \ *.html,*.xml,*.js,*.svelte,*.vue,*.jsx,*.tsx,*.php ++once call
      \ immTagCo#RestoreCursor()
 :  augroup END
 :endfunction


### PR DESCRIPTION
Write "++once" keyword correctly in autocmd.
The "once" keyword used to run an autocmd only one time only works when prefixed with 2 plus signs like "++once".